### PR TITLE
Making GraphQL to show up on the website

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cron": "latest",
     "request": "latest",
     "memory-cache": "latest",
-    "lodash": "latest",
+    "lodash": "^3.10.0",
     "lowdb": "^0.10.2",
     "locale": "^0.0.20",
     "i18n": "^0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,13 +1208,9 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash@^3.1.0, lodash@^3.10.1:
+lodash@^3.1.0, lodash@^3.10.0, lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@latest:
-  version "4.16.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.4.tgz#01ce306b9bad1319f2a5528674f88297aeb70127"
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Sadly, website wasn't showing up GraphQL.
As it breaks using lodash@latest bcz its using _.contains which was removed after 3.10.0.
So I have changed it to 3.10.0 to make it work :smiley: 