### PR TITLE
Added padding to bottom of panels

### DIFF
--- a/public/css/styles.less
+++ b/public/css/styles.less
@@ -135,3 +135,7 @@ div.tagsinput div { display:block; float: left; }
 .list-group h4:last-child {
     padding-bottom: 10px; 
 }
+
+.panel {
+    padding-bottom: 0.5em;
+}


### PR DESCRIPTION
Bottom of panels looked off, adding a 0.5em padding between the text and the bottom of the box makes it match the padding on the top of the box.